### PR TITLE
Connecting the StatsGUI to the rest of the display

### DIFF
--- a/src/main/java/interface_adapter/game_stats/GameStatsPresenter.java
+++ b/src/main/java/interface_adapter/game_stats/GameStatsPresenter.java
@@ -1,0 +1,14 @@
+package interface_adapter.game_stats;
+
+import use_case.game_stats.GameStatsOutputBoundary;
+import use_case.game_stats.GameStatsOutputData;
+import view.StatsGUI;
+
+public class GameStatsPresenter implements GameStatsOutputBoundary {
+    public GameStatsPresenter() {}
+
+    public void prepareSuccessView(GameStatsOutputData gameStatsOutputData) {
+        new StatsGUI(gameStatsOutputData);
+        //Pass question list from outputdata to GameGUI
+    }
+}

--- a/src/main/java/use_case/game_stats/GameStatsOutputBoundary.java
+++ b/src/main/java/use_case/game_stats/GameStatsOutputBoundary.java
@@ -2,5 +2,5 @@ package use_case.game_stats;
 
 public interface GameStatsOutputBoundary {
     void prepareSuccessView(GameStatsOutputData placeholder1);
-    void prepareFailView(String error);
+    //void prepareFailView(String error);
 }

--- a/src/main/java/use_case/game_stats/GameStatsOutputData.java
+++ b/src/main/java/use_case/game_stats/GameStatsOutputData.java
@@ -39,11 +39,11 @@ public class GameStatsOutputData {
 //        return numQuestions;
 //    }
 
-    public int getPoints1() {
+    public int getPlayerPoints() {
         return playerPoints;
     }
 
-    public int getPoints2() {
+    public int getComputerPoints() {
         return computerPoints;
     }
 

--- a/src/main/java/view/GameGUI.java
+++ b/src/main/java/view/GameGUI.java
@@ -29,6 +29,8 @@ import use_case.game_stats.GameStatsInteractor;
 import use_case.game_stats.GameStatsOutputBoundary;
 import use_case.game_stats.GameStatsOutputData;
 
+import interface_adapter.game_stats.GameStatsPresenter;
+
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,6 +54,7 @@ public class GameGUI extends JFrame {
         this.computer = computer;
         setTitle("CardLayout Example");
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setExtendedState(getExtendedState() | JFrame.MAXIMIZED_BOTH);
         setSize(400, 300);
 
         cardLayout = new CardLayout();
@@ -87,7 +90,7 @@ public class GameGUI extends JFrame {
                     GameStatsInputBoundary gameStatsInputInteractor = new GameStatsInteractor(gameStatsOutputBoundary);
                     GameStatsController gameStatsController = new GameStatsController(gameStatsInputInteractor);
                     gameStatsController.execute(player, computer);
-
+                    GameGUI.super.dispose();
                 }
 
             }
@@ -104,9 +107,13 @@ public class GameGUI extends JFrame {
 
     public JPanel createCard(Question question) {
         JPanel mainPanel = new JPanel();
+        mainPanel.setBorder(BorderFactory.createEmptyBorder(500, 350, 300, 400));
+
+        Font largeFont = new Font("Arial", Font.PLAIN, 20);
 
         String q = question.getQuestion();
         JLabel questionText = new JLabel(q);
+        questionText.setFont(largeFont);
         mainPanel.add(questionText, BorderLayout.NORTH);
 
         TitledBorder title;

--- a/src/main/java/view/StatsGUI.java
+++ b/src/main/java/view/StatsGUI.java
@@ -1,6 +1,7 @@
 package view;
 
 import entity.GameStats;
+import use_case.game_stats.GameStatsOutputData;
 
 import javax.swing.*;
 import java.awt.*;
@@ -10,7 +11,7 @@ import java.awt.event.ActionEvent;
 public class StatsGUI extends JFrame {
 
 
-    public StatsGUI(GameStats gameStats) {
+    public StatsGUI(GameStatsOutputData gameStatsOutputData) {
 
         JLabel background = new JLabel();
         JPanel statsPanel = new JPanel();
@@ -20,8 +21,8 @@ public class StatsGUI extends JFrame {
 
         statsPanel.setBorder(BorderFactory.createEmptyBorder(250, 400, 250, 400));
         statsPanel.setLayout(new GridLayout(3, 2, 10, 10));
-        int playerScore = gameStats.getPlayerPoints();
-        int computerScore = gameStats.getComputerPoints();
+        int playerScore = gameStatsOutputData.getPlayerPoints();
+        int computerScore = gameStatsOutputData.getComputerPoints();
 
         Font font = new Font("Arial", Font.BOLD, 30);
         JLabel playerScoreLbl = new JLabel("Player score:");


### PR DESCRIPTION
GAME_STATS_PRESENTER
- created GameStatsPresenter so that we can switch to the StatsGUI in the GameGUI
- made some alterations to StatsGUI to better follow CA (passing in output data rather than an entity)

EDITS TO GAME_GUI
- made it look better (open question selection as full screen, increase text size)
- connected the last question to starting the StatsGUI

NEXT TIME
- figure out how to update the points display in the gui